### PR TITLE
class-validator-patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
     "up": "yarn && yarn start:dev"
   },
   "resolutions": {
-    "ansi-regex": "^5.0.1",
-    "class-transformer": "0.4.0",
-    "class-validator": "0.13.1"
+    "ansi-regex": "^5.0.1"
   },
   "dependencies": {
     "@nestjs/common": "^8.1.1",
@@ -40,7 +38,7 @@
     "@nestjs/typeorm": "8.0.3",
     "@us-epa-camd/easey-common": "11.1.0",
     "class-transformer": "0.4.0",
-    "class-validator": "0.13.1",
+    "class-validator": "^0.13.1",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "nest-router": "^1.0.9",


### PR DESCRIPTION
reverting back to "class-validator": "^0.13.1" to resolve cloud.gov deployment issue