### PR TITLE
Fix/3654 refactor account attribute code

### DIFF
--- a/src/facilities/facility-unit-attributes.repository.spec.ts
+++ b/src/facilities/facility-unit-attributes.repository.spec.ts
@@ -19,6 +19,7 @@ import { FacilityUnitAttributes } from '../entities/vw-facility-unit-attributes.
 const mockQueryBuilder = () => ({
   andWhere: jest.fn(),
   getMany: jest.fn(),
+  getManyAndCount: jest.fn(),
   select: jest.fn(),
   orderBy: jest.fn(),
   addOrderBy: jest.fn(),
@@ -27,6 +28,15 @@ const mockQueryBuilder = () => ({
   take: jest.fn(),
   getQueryAndParameters: jest.fn(),
 });
+
+const mockRequest = (url: string) => {
+  return {
+    url,
+    res: {
+      setHeader: jest.fn(),
+    },
+  };
+};
 
 const filters: PaginatedFacilityAttributesParamsDTO = new PaginatedFacilityAttributesParamsDTO();
 filters.page = undefined;
@@ -44,8 +54,9 @@ filters.programCodeInfo = [Program.ARP, Program.RGGI];
 filters.sourceCategory = [SourceCategory.AUTOMOTIVE_STAMPINGS];
 
 describe('FacilityUnitAttributesRepository', () => {
-  let facilityUnitAttributesRepository;
-  let queryBuilder;
+  let facilityUnitAttributesRepository:FacilityUnitAttributesRepository;
+  let queryBuilder:any;
+  let req: any;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
@@ -61,6 +72,8 @@ describe('FacilityUnitAttributesRepository', () => {
     queryBuilder = module.get<SelectQueryBuilder<FacilityUnitAttributes>>(
       SelectQueryBuilder,
     );
+    req = mockRequest('');
+    req.res.setHeader.mockReturnValue();
 
     facilityUnitAttributesRepository.createQueryBuilder = jest
       .fn()
@@ -73,6 +86,10 @@ describe('FacilityUnitAttributesRepository', () => {
     queryBuilder.take.mockReturnValue('mockPagination');
     queryBuilder.getCount.mockReturnValue('mockCount');
     queryBuilder.getMany.mockReturnValue('mockFacilityAttributes');
+    queryBuilder.getManyAndCount.mockReturnValue([
+      'mockFacilityAttributes',
+      0,
+    ]);
     queryBuilder.getQueryAndParameters.mockReturnValue('');
   });
 
@@ -81,11 +98,11 @@ describe('FacilityUnitAttributesRepository', () => {
       // branch coverage
       const emptyFilters: PaginatedFacilityAttributesParamsDTO = new PaginatedFacilityAttributesParamsDTO();
       let result = await facilityUnitAttributesRepository.getAllFacilityAttributes(
-        emptyFilters,
+        emptyFilters,req
       );
 
       result = await facilityUnitAttributesRepository.getAllFacilityAttributes(
-        filters,
+        filters,req
       );
 
       expect(queryBuilder.getMany).toHaveBeenCalled();
@@ -102,7 +119,7 @@ describe('FacilityUnitAttributesRepository', () => {
       paginatedFilters.perPage = 10;
 
       const paginatedResult = await facilityUnitAttributesRepository.getAllFacilityAttributes(
-        paginatedFilters,
+        paginatedFilters,req
       );
 
       expect(ResponseHeaders.setPagination).toHaveBeenCalled();

--- a/src/facilities/facility-unit-attributes.repository.ts
+++ b/src/facilities/facility-unit-attributes.repository.ts
@@ -178,6 +178,8 @@ export class FacilityUnitAttributesRepository extends Repository<
     req: Request,
     allowedOrisCodes?: number[],
   ): Promise<FacilityUnitAttributes[]> {
+    let totalCount: number;
+    let results: FacilityUnitAttributes[];
     const { page, perPage } = facilityAttributesParamsDTO;
     const query = this.buildQuery(facilityAttributesParamsDTO);
 
@@ -189,11 +191,12 @@ export class FacilityUnitAttributesRepository extends Repository<
 
     if (page && perPage) {
       query.skip((page - 1) * perPage).take(perPage);
-      const totalCount = await query.getCount();
+      [results, totalCount] = await query.getManyAndCount();
       ResponseHeaders.setPagination(req, page, perPage, totalCount);
+    } else {
+      results = await query.getMany();
     }
-
-    return query.getMany();
+    return results;
   }
 
   async lastArchivedYear(): Promise<number> {


### PR DESCRIPTION
## Ticket
[Refactor Account Attributes code](https://app.zenhub.com/workspaces/dpcerg-scrum-board-5f36cc8dfed6db0022b0f4db/issues/gh/us-epa-camd/easey-ui/3654)

## Changes

- Refactored `Facility Unit Attributes` APIs.
- Updated `Facility Unit Attributes` test cases.

## Step to test

1. `easey-campd-ui` connect to `easey-facilities-api` using  `REACT_APP_EASEY_FACILITIES_API` in locally
2. Navigate to http://localhost:3000/data/custom-data-download
3. Select `Data Type` as `Facility` and Apply
4. Enter `Time Period` (eg: year 2019) and Apply Filter
5. Click `Preview Data` button and check total count and result.