### PR TITLE
fix:remove extra space in ownerOperater

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@nestjs/platform-express": "^8.1.1",
     "@nestjs/swagger": "^5.1.2",
     "@nestjs/typeorm": "8.0.3",
-    "@us-epa-camd/easey-common": "11.4.3",
+    "@us-epa-camd/easey-common": "11.4.4",
     "class-transformer": "0.4.0",
     "class-validator": "^0.13.1",
     "dotenv": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,10 +1184,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@us-epa-camd/easey-common@11.4.3":
-  version "11.4.3"
-  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/11.4.3/bb5470d178e5f1a2734c44705786a06a19bf5184#bb5470d178e5f1a2734c44705786a06a19bf5184"
-  integrity sha512-Ur+6nYPlLWgewygUq17cxXwwq/hPIhkPjyxB6qCL5eUXW0EOHxeu4YBVK7bRVDz9oTgm7Dhw1KZq/sGjpCjeyA==
+"@us-epa-camd/easey-common@11.4.4":
+  version "11.4.4"
+  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/11.4.4/0cd685717fbb51bcc5b74dfa40fc4c06d695468d#0cd685717fbb51bcc5b74dfa40fc4c06d695468d"
+  integrity sha512-28xYBYn5vemjI7Jexj4JWsYZS9qc5j7Oaytz0j/3cybgrYxx5sbQiB9bRepjWRdOMysuR1zcpfeRLKAMLr/pmg==
   dependencies:
     "@nestjs/axios" "0.0.3"
     "@nestjs/common" "^8.1.1"


### PR DESCRIPTION
## Ticket 
[Change delimiter in OwnerOperator](https://github.com/US-EPA-CAMD/easey-ui/issues/4888#issuecomment-2077900692)

## Change

- Remove extra space from `ownerOperator` swagger example

## Step to test

1. Check swagger `ownerOperator` example value