### PR TITLE
fix(6185): addressed return value changing from undefined to null

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nestjs/platform-express": "^8.4.7",
     "@nestjs/swagger": "^5.1.2",
     "@nestjs/typeorm": "^8.0.3",
-    "@us-epa-camd/easey-common": "17.3.1",
+    "@us-epa-camd/easey-common": "17.4.1",
     "class-transformer": "0.4.0",
     "class-validator": "^0.14.0",
     "dotenv": "^10.0.0",

--- a/src/facilities-workspace/facilities.service.ts
+++ b/src/facilities-workspace/facilities.service.ts
@@ -95,7 +95,7 @@ export class FacilitiesWorkspaceService {
       facilityId: id,
     });
 
-    if (facility === undefined) {
+    if (!facility) {
       throw new EaseyException(
         new Error('Facility id does not exist'),
         HttpStatus.INTERNAL_SERVER_ERROR,

--- a/src/facilities/facilities.service.ts
+++ b/src/facilities/facilities.service.ts
@@ -79,7 +79,7 @@ export class FacilitiesService {
       facilityId: id,
     });
 
-    if (facility === undefined) {
+    if (!facility) {
       throw new EaseyException(
         new Error('Facility id does not exist'),
         HttpStatus.INTERNAL_SERVER_ERROR,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1196,10 +1196,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@us-epa-camd/easey-common@^17.3.0":
-  version "17.3.0"
-  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.3.0/c64c78e4a7eaaec7e370d840fa032350f123c151#c64c78e4a7eaaec7e370d840fa032350f123c151"
-  integrity sha512-R3o7AgI5frUp8/Zp6vkDoy9A4mEFDw/fDemeArON8uA5Gfqlt9CCI5oR7pITBSIu/tGpqdBvhrshis5sBEIx+g==
+"@us-epa-camd/easey-common@17.4.1":
+  version "17.4.1"
+  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.4.1/f48111f38d5204b5d7d308a7dffc9c202f0e083e#f48111f38d5204b5d7d308a7dffc9c202f0e083e"
+  integrity sha512-rgU7sceWwUiavS4QDnE4ntLPQJzY8zjK1eT042QJH/UXcHYkE22LQQRW4toU+g4LTknFa3NvvjS3Az52B4vHAA==
   dependencies:
     "@golevelup/ts-jest" "^0.3.4"
     "@nestjs/axios" "0.0.3"
@@ -1209,7 +1209,7 @@
     "@nestjs/swagger" "^5.1.2"
     class-validator "^0.14.0"
     dotenv "^10.0.0"
-    express "^4.17.3"
+    express "^4.19.2"
     helmet "^4.6.0"
     json2csv "^5.0.6"
     pg "^8.11.5"
@@ -2807,7 +2807,7 @@ express@4.18.1:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-express@^4.17.3, express@^4.19.2:
+express@^4.19.2:
   version "4.19.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.19.2.tgz#e25437827a3aa7f2a827bc8171bbbb664a356465"
   integrity sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==


### PR DESCRIPTION
## Changes

In the previous changes made in response to the TypeORM update, I overlooked one breaking change noted in the [release notes](https://github.com/typeorm/typeorm/releases/tag/0.3.0):
> findOne and QueryBuilder.getOne() now return null instead of undefined in the case if it didn't find anything in the database.
Logically it makes more sense to return null.

This means that all explicit comparisons against `undefined` should be changed to `null` (alternatively, since the method will return either a complex type or `null`, one can just check if it is falsy).