### PR TITLE
fix(5995): pass oris code to routes instead of facility ID

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,6 @@ module.exports = {
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
     'prettier',
-    'prettier/@typescript-eslint',
   ],
   root: true,
   env: {

--- a/src/entities/workspace/plant.entity.ts
+++ b/src/entities/workspace/plant.entity.ts
@@ -1,0 +1,55 @@
+import {
+  BaseEntity,
+  Entity,
+  Column,
+  OneToMany,
+  PrimaryColumn,
+  Unique,
+} from 'typeorm';
+import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
+
+import { StackPipe } from './stack-pipe.entity';
+import { Unit } from './unit.entity';
+
+@Entity({ name: 'camd.plant' })
+@Unique('uq_plant_oris_code', ['facilityId'])
+@Unique('uq_plant_name_state', ['facilityName', 'stateCode'])
+export class Plant extends BaseEntity {
+  @PrimaryColumn({
+    name: 'fac_id',
+    transformer: new NumericColumnTransformer(),
+  })
+  id: number;
+
+  @Column({
+    name: 'oris_code',
+    transformer: new NumericColumnTransformer(),
+  })
+  facilityId: number;
+
+  @Column({
+    name: 'facility_name',
+  })
+  facilityName: string;
+
+  @Column({ name: 'state' })
+  stateCode: string;
+
+  @Column({
+    name: 'epa_region',
+    transformer: new NumericColumnTransformer(),
+  })
+  epaRegion: number;
+
+  @OneToMany(
+    () => StackPipe,
+    stackPipe => stackPipe.plant,
+  )
+  stackPipes: StackPipe[];
+
+  @OneToMany(
+    () => Unit,
+    unit => unit.plant,
+  )
+  units: Unit[];
+}

--- a/src/entities/workspace/stack-pipe.entity.ts
+++ b/src/entities/workspace/stack-pipe.entity.ts
@@ -1,6 +1,15 @@
-import { BaseEntity, Entity, Column, OneToMany, PrimaryColumn } from 'typeorm';
+import {
+  ManyToOne,
+  JoinColumn,
+  BaseEntity,
+  Entity,
+  Column,
+  OneToMany,
+  PrimaryColumn,
+} from 'typeorm';
 import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 
+import { Plant } from './plant.entity';
 import { UnitStackConfiguration } from './unit-stack-configuration.entity';
 
 @Entity({ name: 'camdecmpswks.stack_pipe' })
@@ -43,6 +52,13 @@ export class StackPipe extends BaseEntity {
 
   @Column({ type: 'timestamp', name: 'update_date' })
   updateDate: Date;
+
+  @ManyToOne(
+    () => Plant,
+    plant => plant.stackPipes,
+  )
+  @JoinColumn({ name: 'fac_id' })
+  plant: Plant;
 
   @OneToMany(
     () => UnitStackConfiguration,

--- a/src/entities/workspace/unit.entity.ts
+++ b/src/entities/workspace/unit.entity.ts
@@ -1,15 +1,18 @@
+import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 import {
   BaseEntity,
-  Entity,
   Column,
-  PrimaryColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
   OneToMany,
   OneToOne,
+  PrimaryColumn,
 } from 'typeorm';
-import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 
-import { UnitOpStatus } from './unit-op-status.entity';
 import { MonitorLocation } from './monitor-location.entity';
+import { Plant } from './plant.entity';
+import { UnitOpStatus } from './unit-op-status.entity';
 import { UnitStackConfiguration } from './unit-stack-configuration.entity';
 
 @Entity({ name: 'camd.unit' })
@@ -53,6 +56,13 @@ export class Unit extends BaseEntity {
     transformer: new NumericColumnTransformer(),
   })
   facId: number;
+
+  @ManyToOne(
+    () => Plant,
+    plant => plant.units,
+  )
+  @JoinColumn({ name: 'fac_id' })
+  plant: Plant;
 
   @OneToOne(
     () => MonitorLocation,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -16,15 +16,15 @@ const routes: Routes = [
     module: FacilitiesWorkspaceModule,
     children: [
       {
-        path: '/:facId/units',
+        path: '/:orisCode/units',
         module: UnitWorkspaceModule,
       },
       {
-        path: '/:facId/stack-pipes',
+        path: '/:orisCode/stack-pipes',
         module: StackPipeWorkspaceModule,
       },
       {
-        path: '/:facId/unit-stack-configurations',
+        path: '/:orisCode/unit-stack-configurations',
         module: UnitStackConfigurationWorkspaceModule,
       },
     ],

--- a/src/stack-pipe-workspace/stack-pipe.controller.ts
+++ b/src/stack-pipe-workspace/stack-pipe.controller.ts
@@ -16,17 +16,17 @@ export class StackPipeWorkspaceController {
   @ApiOkResponse({
     isArray: true,
     type: StackPipeDTO,
-    description: 'Retrieves a list of stacks/pipes by facility ID',
+    description: 'Retrieves a list of stacks/pipes by oris code',
   })
   @RoleGuard(
     {
       enforceCheckout: false,
-      pathParam: 'facId',
+      pathParam: 'orisCode',
       enforceEvalSubmitCheck: false,
     },
     LookupType.Facility,
   )
-  getStackPipesByFacId(@Param('facId') facId: number) {
-    return this.service.getStackPipesByFacId(facId);
+  getStackPipesByOrisCode(@Param('orisCode') orisCode: number) {
+    return this.service.getStackPipesByOrisCode(orisCode);
   }
 }

--- a/src/stack-pipe-workspace/stack-pipe.service.spec.ts
+++ b/src/stack-pipe-workspace/stack-pipe.service.spec.ts
@@ -52,7 +52,7 @@ describe('StackPipe Workspace Tests', () => {
       const stackPipes = stackPipeList.filter(u => u.facId === 2);
       const stackPipesDto = await map.many(stackPipes);
       jest.spyOn(repository, 'findBy').mockResolvedValue(stackPipes);
-      const results = await service.getStackPipesByFacId(2);
+      const results = await service.getStackPipesByOrisCode(5);
       expect(results).toStrictEqual(stackPipesDto);
     });
   });

--- a/src/stack-pipe-workspace/stack-pipe.service.ts
+++ b/src/stack-pipe-workspace/stack-pipe.service.ts
@@ -10,8 +10,10 @@ export class StackPipeWorkspaceService {
     private readonly map: StackPipeMap,
   ) {}
 
-  async getStackPipesByFacId(facId: number) {
-    const results = await this.repository.findBy({ facId });
+  async getStackPipesByOrisCode(orisCode: number) {
+    const results = await this.repository.findBy({
+      plant: { facilityId: orisCode },
+    });
     return this.map.many(results);
   }
 }

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration.controller.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration.controller.ts
@@ -18,17 +18,17 @@ export class UnitStackConfigurationWorkspaceController {
   @ApiOkResponse({
     isArray: true,
     type: UnitStackConfigurationDTO,
-    description: 'Retrieves a list of unit stack configurations by facility ID',
+    description: 'Retrieves a list of unit stack configurations by oris code',
   })
   @RoleGuard(
     {
       enforceCheckout: false,
-      pathParam: 'facId',
+      pathParam: 'orisCode',
       enforceEvalSubmitCheck: false,
     },
     LookupType.Facility,
   )
-  getUnitStackConfigurationsByFacId(@Param('facId') facId: number) {
-    return this.service.getUnitStackConfigurationsByFacId(facId);
+  getUnitStackConfigurationsByOrisCode(@Param('orisCode') orisCode: number) {
+    return this.service.getUnitStackConfigurationsByOrisCode(orisCode);
   }
 }

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration.service.spec.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration.service.spec.ts
@@ -57,7 +57,7 @@ describe('UnitStackConfiguration Workspace Tests', () => {
       const unitStackConfigs = unitStackConfigList.filter(u => u.unitId === 2);
       const unitStackConfigsDto = await map.many(unitStackConfigs);
       jest.spyOn(repository, 'find').mockResolvedValue(unitStackConfigs);
-      const results = await service.getUnitStackConfigurationsByFacId(1);
+      const results = await service.getUnitStackConfigurationsByOrisCode(5);
       expect(results).toStrictEqual(unitStackConfigsDto);
     });
   });

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
@@ -10,13 +10,16 @@ export class UnitStackConfigurationWorkspaceService {
     private readonly map: UnitStackConfigurationMap,
   ) {}
 
-  async getUnitStackConfigurationsByFacId(facId: number) {
+  async getUnitStackConfigurationsByOrisCode(orisCode: number) {
     const results = await this.repository.find({
       relations: {
         stackPipe: true,
         unit: true,
       },
-      where: [{ unit: { facId } }, { stackPipe: { facId } }],
+      where: [
+        { unit: { plant: { facilityId: orisCode } } },
+        { stackPipe: { plant: { facilityId: orisCode } } },
+      ],
     });
     return this.map.many(results);
   }

--- a/src/unit-workspace/unit.controller.ts
+++ b/src/unit-workspace/unit.controller.ts
@@ -16,17 +16,17 @@ export class UnitWorkspaceController {
   @ApiOkResponse({
     isArray: true,
     type: UnitDTO,
-    description: 'Retrieves a list of units by facility ID',
+    description: 'Retrieves a list of units by facility oris code',
   })
   @RoleGuard(
     {
       enforceCheckout: false,
-      pathParam: 'facId',
+      pathParam: 'orisCode',
       enforceEvalSubmitCheck: false,
     },
     LookupType.Facility,
   )
-  getUnitsByFacId(@Param('facId') facId: number) {
-    return this.service.getUnitsByFacId(facId);
+  getUnitsByOrisCode(@Param('orisCode') orisCode: number) {
+    return this.service.getUnitsByOrisCode(orisCode);
   }
 }

--- a/src/unit-workspace/unit.service.spec.ts
+++ b/src/unit-workspace/unit.service.spec.ts
@@ -54,7 +54,7 @@ describe('Unit Workspace Tests', () => {
       const units = unitList.filter(u => u.facId === 2);
       const unitsDto = await map.many(units);
       jest.spyOn(repository, 'find').mockResolvedValue(units);
-      const results = await service.getUnitsByFacId(2);
+      const results = await service.getUnitsByOrisCode(5);
       expect(results).toStrictEqual(unitsDto);
     });
   });

--- a/src/unit-workspace/unit.service.ts
+++ b/src/unit-workspace/unit.service.ts
@@ -10,9 +10,13 @@ export class UnitWorkspaceService {
     private readonly map: UnitMap,
   ) {}
 
-  async getUnitsByFacId(facId: number) {
+  async getUnitsByOrisCode(orisCode: number) {
     const results = await this.repository.find({
-      where: { facId },
+      where: {
+        plant: {
+          facilityId: orisCode,
+        },
+      },
       relations: {
         location: {
           methods: true,


### PR DESCRIPTION
## Related Issues:

- [#5995](https://github.com/US-EPA-CAMD/easey-ui/issues/5995)

## Main Changes:

- Switched from passing the `facId` to passing the `orisCode` to routes. The latter is expected by the Roles Guard when using `LookupType.Facility`.
- Removed `prettier/@typescript-eslint` from the eslint config, since it's been merged into version 8 of `eslint-config-prettier`.