### PR TITLE
Feature/5995 configuration manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nestjs/platform-express": "^8.4.7",
     "@nestjs/swagger": "^5.1.2",
     "@nestjs/typeorm": "^8.0.3",
-    "@us-epa-camd/easey-common": "^17.5.0",
+    "@us-epa-camd/easey-common": "^17.7.2",
     "class-transformer": "0.4.0",
     "class-validator": "^0.14.0",
     "dotenv": "^10.0.0",

--- a/src/dtos/unit.dto.ts
+++ b/src/dtos/unit.dto.ts
@@ -113,4 +113,12 @@ export class UnitDTO {
     },
   })
   nonLoadBasedIndicator: number;
+
+  @ApiProperty({
+    description: propertyMetadata.unitDTOOpStatusCd.description,
+    example: propertyMetadata.unitDTOOpStatusCd.example,
+    name: propertyMetadata.unitDTOOpStatusCd.fieldLabels.value,
+  })
+  @IsString()
+  opStatusCd: string;
 }

--- a/src/maps/unit.map.ts
+++ b/src/maps/unit.map.ts
@@ -31,6 +31,20 @@ export class UnitMap extends BaseMap<Unit | UnitWorkspace, UnitDTO> {
       : null;
   }
 
+  private getOpStatusCode(entity: Unit | UnitWorkspace): string {
+    const opStatuses = entity.opStatuses;
+    if (!opStatuses) return null;
+
+    const activeOpStatus = opStatuses.reduce((acc, cur) => {
+      if (!acc) return cur;
+      if (new Date(cur.beginDate).getTime() > new Date(acc.beginDate).getTime()) {
+        return cur;
+      }
+    }, null);
+
+    return activeOpStatus?.opStatusCode ?? null;
+  }
+
   public async one(entity: Unit | UnitWorkspace): Promise<UnitDTO> {
     return {
       id: entity.id,
@@ -39,6 +53,7 @@ export class UnitMap extends BaseMap<Unit | UnitWorkspace, UnitDTO> {
       beginDate: this.getBeginDate(entity),
       endDate: this.getEndDate(entity),
       nonLoadBasedIndicator: entity.nonLoadBasedIndicator,
+      opStatusCd: this.getOpStatusCode(entity),
       associatedMonitorPlanIds:
         entity.location?.plans?.map(plan => plan.id) ?? [],
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1196,10 +1196,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@us-epa-camd/easey-common@^17.5.0":
-  version "17.5.0"
-  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.5.0/e031796c891b52b87ca23f8533af149a05350f61#e031796c891b52b87ca23f8533af149a05350f61"
-  integrity sha512-TxFfP9DfHCK0EIPqtHOH2jZlLtaEHGGaMoXxAvqS70Pok7vf7rnKRoDgeRFE6HPV9syl5yDAteMmydd31GMWfg==
+"@us-epa-camd/easey-common@^17.7.2":
+  version "17.7.2"
+  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.7.2/40f9f765a640374bc2fa0c8f1610d3a7ce6da3ad#40f9f765a640374bc2fa0c8f1610d3a7ce6da3ad"
+  integrity sha512-q6CqFe8BDTaPR86e3RXHtreM9Z82Fp0TWrvxfFYO7jbm3l8w7KR9sr2bqwZnYfvyA9d4ZZIYZVNxQzvl+dDrXg==
   dependencies:
     "@golevelup/ts-jest" "^0.3.4"
     "@nestjs/axios" "0.0.3"
@@ -1209,7 +1209,7 @@
     "@nestjs/swagger" "^5.1.2"
     class-validator "^0.14.0"
     dotenv "^10.0.0"
-    express "^4.19.2"
+    express "^4.20.0"
     helmet "^4.6.0"
     json2csv "^5.0.6"
     pg "^8.11.5"
@@ -2844,7 +2844,7 @@ express@4.18.1:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-express@^4.19.2, express@^4.20.0:
+express@^4.20.0:
   version "4.20.0"
   resolved "https://registry.yarnpkg.com/express/-/express-4.20.0.tgz#f1d08e591fcec770c07be4767af8eb9bcfd67c48"
   integrity sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==


### PR DESCRIPTION
## Related Issues:

- [#5995](https://github.com/US-EPA-CAMD/easey-ui/issues/5995)

## Main Changes:

- Added the `opStatusCd` field to the Unit DTO. This is used by the ECMPS Configuration Manager to filter to units that are available to form a Monitoring Plan.