### PR TITLE
fix:exclude workspace api from swagger beta env

### DIFF
--- a/src/facilities-workspace/facilities.controller.ts
+++ b/src/facilities-workspace/facilities.controller.ts
@@ -23,6 +23,7 @@ import {
 import { Json2CsvInterceptor } from '@us-epa-camd/easey-common/interceptors';
 
 import {
+  ApiExcludeEndpointByEnv,
   ApiQueryAttributesMultiSelect,
   BadRequestResponse,
   NotFoundResponse,
@@ -50,6 +51,7 @@ export class FacilitiesWorkspaceController {
 
   @Get()
   @RoleGuard({}, LookupType.Facility)
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Retrieves a list of Facilities',
   })
@@ -66,6 +68,7 @@ export class FacilitiesWorkspaceController {
 
   @Get('/attributes')
   @RoleGuard({}, LookupType.Facility)
+  @ApiExcludeEndpointByEnv()
   @UseInterceptors(Json2CsvInterceptor)
   @ApiOkResponse({
     description: 'Retrieves Facility Unit Attributes',
@@ -104,6 +107,7 @@ export class FacilitiesWorkspaceController {
 
   @Get('/attributes/applicable')
   @RoleGuard({}, LookupType.Facility)
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Retrieves Applicable Facility Attributes',
   })
@@ -129,6 +133,7 @@ export class FacilitiesWorkspaceController {
 
   @Get('/:id')
   @RoleGuard({ pathParam: 'id' }, LookupType.Facility)
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Retrieves a single Facilitiy By Id',
   })

--- a/src/stack-pipe-workspace/stack-pipe.controller.ts
+++ b/src/stack-pipe-workspace/stack-pipe.controller.ts
@@ -5,6 +5,7 @@ import { LookupType } from '@us-epa-camd/easey-common/enums';
 
 import { StackPipeDTO } from '../dtos/stack-pipe.dto';
 import { StackPipeWorkspaceService } from './stack-pipe.service';
+import { ApiExcludeEndpointByEnv } from '../utils/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -26,6 +27,7 @@ export class StackPipeWorkspaceController {
     },
     LookupType.Facility,
   )
+  @ApiExcludeEndpointByEnv()
   getStackPipesByOrisCode(@Param('orisCode') orisCode: number) {
     return this.service.getStackPipesByOrisCode(orisCode);
   }

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration.controller.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration.controller.ts
@@ -5,6 +5,7 @@ import { LookupType } from '@us-epa-camd/easey-common/enums';
 
 import { UnitStackConfigurationDTO } from '../dtos/unit-stack-configuration.dto';
 import { UnitStackConfigurationWorkspaceService } from './unit-stack-configuration.service';
+import { ApiExcludeEndpointByEnv } from '../utils/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -28,6 +29,7 @@ export class UnitStackConfigurationWorkspaceController {
     },
     LookupType.Facility,
   )
+  @ApiExcludeEndpointByEnv()
   getUnitStackConfigurationsByOrisCode(@Param('orisCode') orisCode: number) {
     return this.service.getUnitStackConfigurationsByOrisCode(orisCode);
   }

--- a/src/unit-workspace/unit.controller.ts
+++ b/src/unit-workspace/unit.controller.ts
@@ -5,6 +5,7 @@ import { LookupType } from '@us-epa-camd/easey-common/enums';
 
 import { UnitDTO } from '../dtos/unit.dto';
 import { UnitWorkspaceService } from './unit.service';
+import { ApiExcludeEndpointByEnv } from '../utils/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -26,6 +27,7 @@ export class UnitWorkspaceController {
     },
     LookupType.Facility,
   )
+  @ApiExcludeEndpointByEnv()
   getUnitsByOrisCode(@Param('orisCode') orisCode: number) {
     return this.service.getUnitsByOrisCode(orisCode);
   }

--- a/src/utils/swagger-decorator.const.ts
+++ b/src/utils/swagger-decorator.const.ts
@@ -1,5 +1,6 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiBadRequestResponse, ApiNotFoundResponse, ApiQuery } from '@nestjs/swagger';
+import { ApiBadRequestResponse, ApiExcludeController, ApiExcludeEndpoint, ApiNotFoundResponse, ApiQuery } from '@nestjs/swagger';
+import { getConfigValue } from '@us-epa-camd/easey-common/utilities';
 
 export const BadRequestResponse = () =>
   ApiBadRequestResponse({
@@ -28,4 +29,15 @@ export function ExcludeQuery() {
   return applyDecorators(
     ApiQuery({style: 'pipeDelimited', name: 'exclude', required: false, explode: false,})
   );
+}
+
+const env = getConfigValue('EASEY_FACILITIES_API_ENV', 'local-dev');
+const disable = ['local-dev','development','testing'].includes(env) ? false : true;
+
+export function ApiExcludeControllerByEnv() {
+    return applyDecorators(ApiExcludeController(disable));
+}
+
+export function ApiExcludeEndpointByEnv() {
+    return applyDecorators(ApiExcludeEndpoint(disable));
 }


### PR DESCRIPTION
## Ticket
[Exclude facilities-mgmt's workspace API from Swagger page](https://github.com/US-EPA-CAMD/easey-ui/issues/6468)

## Changes

- Create a decorator for exclude APIs end points from swagger page
- Apply created decorated in workspace APIs