### PR TITLE
Feature/7290 CAPAS POST switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # never include npm's package-lock.json when using yarn
 package-lock.json
 
+# build
+tsconfig.build.tsbuildinfo
+
 # dependencies
 /node_modules
 /npm-packages-offline-cache

--- a/manifest-vars.beta.yml
+++ b/manifest-vars.beta.yml
@@ -3,6 +3,7 @@ environment: beta
 host: api-easey-beta.app.cloud.gov
 apiHost: api.epa.gov/easey/beta
 certOfRepApi:  https://cbsprodbeta.epa.gov/CBS/api/facilities-mgmt/certOfRep
+certOfRepApiMethod: GET
 maxConnectionPool: 15
 idleTimeout: 30000
 connectionTimeout: 10000

--- a/manifest-vars.perf.yml
+++ b/manifest-vars.perf.yml
@@ -3,6 +3,7 @@ environment: performance
 host: api-easey-perf.app.cloud.gov
 apiHost: api.epa.gov/easey/perf
 certOfRepApi:  https://cbsstagei.epa.gov/CBSD/api/facilities-mgmt/certOfRep
+certOfRepApiMethod: GET
 maxConnectionPool: 15
 idleTimeout: 30000
 connectionTimeout: 10000

--- a/manifest-vars.prod.yml
+++ b/manifest-vars.prod.yml
@@ -3,6 +3,7 @@ environment: production
 host: api-easey.app.cloud.gov
 apiHost: api.epa.gov/easey
 certOfRepApi: https://camd.epa.gov/CBS/api/facilities-mgmt/certOfRep
+certOfRepApiMethod: GET
 maxConnectionPool: 15
 idleTimeout: 30000
 connectionTimeout: 10000

--- a/manifest-vars.staging.yml
+++ b/manifest-vars.staging.yml
@@ -3,6 +3,7 @@ environment: staging
 host: api-easey-stg.app.cloud.gov
 apiHost: api.epa.gov/easey/staging
 certOfRepApi: https://cbsstagei.epa.gov/CBS/api/facilities-mgmt/certOfRep
+certOfRepApiMethod: GET
 maxConnectionPool: 5
 idleTimeout: 5000
 connectionTimeout: 5000

--- a/manifest-vars.test.yml
+++ b/manifest-vars.test.yml
@@ -3,6 +3,7 @@ environment: testing
 host: api-easey-tst.app.cloud.gov
 apiHost: api.epa.gov/easey/test
 certOfRepApi: https://cbsstagei.epa.gov/CBS/api/facilities-mgmt/certOfRep
+certOfRepApiMethod: GET
 maxConnectionPool: 5
 idleTimeout: 5000
 connectionTimeout: 5000

--- a/manifest-vars.yml
+++ b/manifest-vars.yml
@@ -12,6 +12,7 @@ environment: development
 apiHost: api.epa.gov/easey/dev
 dbSvc: camd-pg-db
 certOfRepApi: https://cbsstagei.epa.gov/CBSD/api/facilities-mgmt/certOfRep
+certOfRepApiMethod: GET
 maxConnectionPool: 15
 idleTimeout: 30000
 connectionTimeout: 10000

--- a/manifest.yml
+++ b/manifest.yml
@@ -31,6 +31,7 @@ applications:
       EASEY_FACILITIES_API_ENABLE_AUTH_TOKEN: true
       TZ: America/New_York
       EASEY_FACILITIES_CERT_OF_REP_API: ((certOfRepApi))
+      EASEY_FACILITIES_CERT_OF_REP_API_METHOD: ((certOfRepApiMethod))
       EASEY_DB_MAX_CONNECTION_POOL: ((maxConnectionPool))
       EASEY_DB_IDLE_TIMEOUT: ((idleTimeout))
       EASEY_DB_CONNECTION_TIMEOUT: ((connectionTimeout))

--- a/src/cert-of-rep/certOfRepList.service.ts
+++ b/src/cert-of-rep/certOfRepList.service.ts
@@ -52,8 +52,8 @@ export class CertOfRepListService {
       }),
     };
 
-    // httpService.request is used so the body can be sent regardless of verb
-    // (axios can't send a body with GET). Non-POST falls back to GET.
+    // httpService.request is used so the body can be sent regardless of verb (axios can't send a body with GET).
+    // The CBS API expects a GET request with a body, CAPAS expects POST.
     const method = this.configService.get<string>('app.certOfRepApiMethod');
     try {
 

--- a/src/cert-of-rep/certOfRepList.service.ts
+++ b/src/cert-of-rep/certOfRepList.service.ts
@@ -52,13 +52,14 @@ export class CertOfRepListService {
       }),
     };
 
-    //The CBS API expects a GET request with a body.
-    //Using the httpService.request method
+    // httpService.request is used so the body can be sent regardless of verb
+    // (axios can't send a body with GET). Non-POST falls back to GET.
+    const method = this.configService.get<string>('app.certOfRepApiMethod');
     try {
 
       const response: AxiosResponse<any> = await firstValueFrom(
         this.httpService.request({
-          method: 'GET',
+          method: method === 'POST' ? 'POST' : 'GET',
           url: certOfRepApiUrl,
           headers: headers,
           data: body,
@@ -122,12 +123,13 @@ export class CertOfRepListService {
     };
 
 
-    //The CBS API expects a GET
+    // Non-POST falls back to GET.
+    const method = this.configService.get<string>('app.certOfRepApiMethod');
     try {
       const response: AxiosResponse<any> = await firstValueFrom(
         this.httpService.request({
-          method: 'GET',
-          url: `${certOfRepApiUrl}/${id}`, 
+          method: method === 'POST' ? 'POST' : 'GET',
+          url: `${certOfRepApiUrl}/${id}`,
           headers: headers,
           data: body,
           ...allowLegacyRenegotiationforNodeJsOptions

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -90,7 +90,6 @@ export default registerAs('app', () => ({
   },
 
   certOfRepApi: getConfigValue('EASEY_FACILITIES_CERT_OF_REP_API', 'https://cbsstagei.epa.gov/CBSD'),
-  // HTTP verb for the cert-of-rep endpoint: 'GET' or 'POST'. Defaults to GET.
   certOfRepApiMethod: getConfigValue('EASEY_FACILITIES_CERT_OF_REP_API_METHOD', 'GET'),
 
   maxConnectionPool: getConfigValueNumber('EASEY_DB_MAX_CONNECTION_POOL',15),

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -90,6 +90,8 @@ export default registerAs('app', () => ({
   },
 
   certOfRepApi: getConfigValue('EASEY_FACILITIES_CERT_OF_REP_API', 'https://cbsstagei.epa.gov/CBSD'),
+  // HTTP verb for the cert-of-rep endpoint: 'GET' or 'POST'. Defaults to GET.
+  certOfRepApiMethod: getConfigValue('EASEY_FACILITIES_CERT_OF_REP_API_METHOD', 'GET'),
 
   maxConnectionPool: getConfigValueNumber('EASEY_DB_MAX_CONNECTION_POOL',15),
   idleTimeout: getConfigValueNumber( 'EASEY_DB_IDLE_TIMEOUT', 30000, ),


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/7290

## Main Changes:

- Add an environment variable to drive the HTTP verb used for the requests in the `CertOfRepListService`. This will need to be set to POST when the target is changed from the CBS service to the CAPAS service. The requests already pass parameters via the body, so only the request method is toggled.